### PR TITLE
Enable CloudFoundry deployment natively

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,10 @@ let server = http.createServer(app);
 
 /**
  * Listen on provided port, on all network interfaces.
+ * Or if it's a cloud native platform like CloudFoundry, get the Port dynamically out of the env.
  */
 
-server.listen(port);
+server.listen(process.env.PORT || port);
 
 server.on('error', err => {
     if (err.syscall !== 'listen') {


### PR DESCRIPTION
Allows to deploy to a CF environment natively, be getting the port dynamically out of the env.