### PR TITLE
Add body size request limit in config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 npm-debug.log
 .DS_Store
 development.toml
+!config/default.toml
+config/*.toml

--- a/app.js
+++ b/app.js
@@ -122,11 +122,16 @@ cspOptions['font-src'] = '\'self\' https://fonts.gstatic.com';
 app.use(csp.getCSP(cspOptions));
 
 app.use(bodyParser.urlencoded({
-    extended: true
+    extended: true,
+    limit: config.www.max_post_size
 }));
 
-app.use(bodyParser.text());
-app.use(bodyParser.json());
+app.use(bodyParser.text({
+    limit: config.www.max_post_size
+}));
+app.use(bodyParser.json({
+    limit: config.www.max_post_size
+}));
 
 passport.setup(app);
 

--- a/config/default.toml
+++ b/config/default.toml
@@ -13,6 +13,8 @@ remember=2592000 # 30 days
 log="dev"
 # is the server behind a proxy? true/false
 proxy=true
+# default is 100kb is too small for production
+max_post_size="20m"
 
 [paging]
 size=20


### PR DESCRIPTION
during days for testing, while sending large batch for mails via SMTP hosts and webhooks enabled. post request of webhook will be 413 entity too large. 

so here is the fix