### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ Edit [mailtrain.nginx](setup/mailtrain.nginx) (update `server_name` directive) a
 
 Edit [mailtrain.conf](setup/mailtrain.conf) (update application folder) and copy it to `/etc/init`
 
+## Nitrous Quickstart
+
+You can quickly create a free development environment for this Mailtrain project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start Mailtrain via `Run > Start Mailtrain` and access your site via `Preview > 3000`.
+
 ## Bounce handling
 
 Mailtrain uses webhooks integration to detect bounces and spam complaints. Currently supported webhooks are:

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your Mailtrain project on Nitrous.
+
+## Running the development server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start Mailtrain via "Run > Start Mailtrain".
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update
+sudo -E apt-get -q -y install mysql-server
+sudo apt-get clean
+
+mysql -u root -e "CREATE USER 'mailtrain'@'localhost' IDENTIFIED BY 'mailtrain';"
+mysql -u root -e "GRANT ALL PRIVILEGES ON mailtrain.* TO 'mailtrain'@'%' WITH GRANT OPTION;"
+mysql -u mailtrain --password="mailtrain" -e "CREATE database mailtrain;"
+mysql -u mailtrain --password="mailtrain" -D mailtrain < setup/mailtrain.sql
+
+cp config/default.toml config/production.toml
+echo "running npm install..."
+npm install --no-progress
+echo "npm install done"

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,9 @@
+{
+  "template": "nodejs",
+  "ports": [3000],
+  "name": "Mailtrain",
+  "description": "Self hosted newsletter app.",
+  "scripts": {
+    "Start Mailtrain": "cd ~/code/mailtrain && NODE_ENV=production npm start"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.