### PR TITLE
Delete subscription endpoint for API

### DIFF
--- a/lib/models/subscriptions.js
+++ b/lib/models/subscriptions.js
@@ -825,16 +825,16 @@ module.exports.changeStatus = (id, listId, campaignId, status, callback) => {
     });
 };
 
-module.exports.delete = (listId, cid, callback) => {
+module.exports.delete = (listId, email, callback) => {
     listId = Number(listId) || 0;
-    cid = (cid || '').toString().trim();
+    email = (email || '').toString().trim();
 
     if (listId < 1) {
         return callback(new Error('Missing List ID'));
     }
 
-    if (!cid) {
-        return callback(new Error('Missing subscription ID'));
+    if (!email) {
+        return callback(new Error('Missing email address'));
     }
 
     db.getConnection((err, connection) => {
@@ -842,7 +842,7 @@ module.exports.delete = (listId, cid, callback) => {
             return callback(err);
         }
 
-        connection.query('SELECT id, email, status FROM `subscription__' + listId + '` WHERE cid=? LIMIT 1', [cid], (err, rows) => {
+        connection.query('SELECT id, email, status FROM `subscription__' + listId + '` WHERE `email`=? LIMIT 1', [email], (err, rows) => {
             if (err) {
                 connection.release();
                 return callback(err);
@@ -860,7 +860,7 @@ module.exports.delete = (listId, cid, callback) => {
                     return callback(err);
                 }
 
-                connection.query('DELETE FROM `subscription__' + listId + '` WHERE cid=? LIMIT 1', [cid], err => {
+                connection.query('DELETE FROM `subscription__' + listId + '` WHERE `email`=? LIMIT 1', [email], err => {
                     if (err) {
                         return connection.rollback(() => {
                             connection.release();
@@ -877,7 +877,7 @@ module.exports.delete = (listId, cid, callback) => {
                                 });
                             }
                             connection.release();
-                            return callback(null, subscription.email);
+                            return callback(null, subscription);
                         });
                     }
 
@@ -896,7 +896,7 @@ module.exports.delete = (listId, cid, callback) => {
                                 });
                             }
                             connection.release();
-                            return callback(null, subscription.email);
+                            return callback(null, subscription);
                         });
                     });
                 });

--- a/routes/api.js
+++ b/routes/api.js
@@ -207,4 +207,57 @@ router.post('/unsubscribe/:listId', (req, res) => {
     });
 });
 
+router.post('/delete/:listId', (req, res) => {
+    let input = {};
+    Object.keys(req.body).forEach(key => {
+        input[(key || '').toString().trim().toUpperCase()] = (req.body[key] || '').toString().trim();
+    });
+    lists.getByCid(req.params.listId, (err, list) => {
+        if (err) {
+            res.status(500);
+            return res.json({
+                error: err.message || err,
+                data: []
+            });
+        }
+        if (!list) {
+            res.status(404);
+            return res.json({
+                error: 'Selected listId not found',
+                data: []
+            });
+        }
+        if (!input.EMAIL) {
+            res.status(400);
+            return res.json({
+                error: 'Missing EMAIL',
+                data: []
+            });
+        }
+        subscriptions.delete(list.id, input.EMAIL, (err, subscription) => {
+            if (err) {
+                res.status(500);
+                return res.json({
+                    error: err.message || err,
+                    data: []
+                });
+            }
+            if (!subscription) {
+                res.status(404);
+                return res.json({
+                    error: 'Subscription not found',
+                    data: []
+                });
+            }
+            res.status(200);
+            res.json({
+                data: {
+                    id: subscription.id,
+                    deleted: true
+                }
+            });
+        });
+    });
+});
+
 module.exports = router;

--- a/routes/lists.js
+++ b/routes/lists.js
@@ -419,14 +419,21 @@ router.post('/subscription/delete', passport.parseForm, passport.csrfProtection,
             return res.redirect('/lists');
         }
 
-        subscriptions.delete(list.id, req.body.cid, (err, email) => {
-            if (err || !email) {
+        subscriptions.get(list.id, req.body.cid, (err, subscription) => {
+            if (err || !subscription) {
                 req.flash('danger', err && err.message || err || 'Could not find subscriber with specified ID');
                 return res.redirect('/lists/view/' + list.id);
             }
 
-            req.flash('success', email + ' was successfully removed from your list');
-            res.redirect('/lists/view/' + list.id);
+            subscriptions.delete(list.id, subscription.email, (err, subscription) => {
+                if (err || !subscription) {
+                    req.flash('danger', err && err.message || err || 'Could not find subscriber with specified ID');
+                    return res.redirect('/lists/view/' + list.id);
+                }
+
+                req.flash('success', subscription.email + ' was successfully removed from your list');
+                res.redirect('/lists/view/' + list.id);
+            });
         });
     });
 });

--- a/views/users/api.hbs
+++ b/views/users/api.hbs
@@ -113,3 +113,30 @@
 
 <pre>curl -XPOST {{serviceUrl}}api/unsubscribe/B16uVTdW?access_token={{accessToken}}\
 --data 'EMAIL=test@example.com'</pre>
+
+<h3>POST /api/delete/:listId – Delete subscription</h3>
+
+<p>
+    This API call deletes a subscription
+</p>
+
+<p>
+    <strong>GET</strong> arguments
+</p>
+<ul>
+    <li><strong>access_token</strong> – your personal access token
+</ul>
+
+<p>
+    <strong>POST</strong> arguments
+</p>
+<ul>
+    <li><strong>EMAIL</strong> – subscriber's email address (<em>required</em>)
+</ul>
+
+<p>
+    <strong>Example</strong>
+</p>
+
+<pre>curl -XPOST {{serviceUrl}}api/delete/B16uVTdW?access_token={{accessToken}}\
+--data 'EMAIL=test@example.com'</pre>


### PR DESCRIPTION
We need it to synchronise all of our users via the API and found some cases where we would like to update the email of a subscription or delete some of them. This endpoint will allow us to do so by deleting old subscriptions and, if needed, replace them with new ones. I replicated the same pattern used for the unsubscribe feature into this new api endpoint, which required a small modification to the model.

Please feel free to comment. It would be great to have this feature supported in the original repository. I'll address any comments that you have. :)

cc @MaheshCasiraghi