### PR TITLE
Add ALT attribute for tracking image

### DIFF
--- a/lib/models/links.js
+++ b/lib/models/links.js
@@ -272,7 +272,7 @@ module.exports.updateLinks = (campaign, list, subscription, serviceUrl, message,
     // insert tracking image
     let inserted = false;
     let imgUrl = urllib.resolve(serviceUrl, util.format('/links/%s/%s/%s', campaign.cid, list.cid, encodeURIComponent(subscription.cid)));
-    let img = '<img src="' + imgUrl + '" width="1" height="1">';
+    let img = '<img src="' + imgUrl + '" width="1" height="1" alt="Tracking Image">';
     message = message.replace(/<\/body\b/i, match => {
         inserted = true;
         return img + match;


### PR DESCRIPTION
Mail Tester gives a bad SPAM score to emails sent via Mailtrain because the tracking image is missing an ALT attribute. See https://www.mail-tester.com/web-x0TwSR for a sample.