### PR TITLE
Add Cloudron installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ You can quickly create a free development environment for this Mailtrain project
 
 In the IDE, start Mailtrain via `Run > Start Mailtrain` and access your site via `Preview > 3000`.
 
+## Cloudron
+
+You can easily install and self-host Mailtrain on the Cloudron to send newsletters from your custom domain:
+
+[![Install](https://cloudron.io/img/button.svg)](https://cloudron.io/button.html?app=org.mailtrain.cloudronapp)
+
+The source code for the Cloudron app is [here](https://git.cloudron.io/cloudron/mailtrain-app).
+
 ## Bounce handling
 
 Mailtrain uses webhooks integration to detect bounces and spam complaints. Currently supported webhooks are:


### PR DESCRIPTION
Hi @andris9,
Thanks for Mailtrain! We have been working on a Mailtrain app for the Cloudron for a while now. Would be great to have it listed as one of the installation methods.

Hopefully this gives some context on why we contributed the LDAP backend - https://github.com/andris9/mailtrain/pull/85. Users of the cloudron authenticate with Mailtrain using LDAP.

You can also play around with the app at https://my-demo.cloudron.me (username: cloudron password: cloudron).

cc @nebulade 