### PR TITLE
Remove unused csv-generate

### DIFF
--- a/lib/models/subscriptions.js
+++ b/lib/models/subscriptions.js
@@ -10,7 +10,6 @@ let settings = require('./settings');
 let mailer = require('../mailer');
 let urllib = require('url');
 let log = require('npmlog');
-let csvGenerate = require('csv-generate');
 
 module.exports.list = (listId, start, limit, callback) => {
     listId = Number(listId) || 0;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "connect-redis": "^3.1.0",
     "cookie-parser": "^1.4.3",
     "csurf": "^1.9.0",
-    "csv-generate": "^1.0.0",
     "csv-parse": "^1.1.7",
     "escape-html": "^1.0.3",
     "express": "^4.14.0",


### PR DESCRIPTION
This came up as `npm test` complained about unused variable.