### PR TITLE
Moved tracking scripts to partial and made tools.formatMessage() less…

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -186,7 +186,7 @@ function formatMessage(serviceUrl, campaign, list, subscription, message, filter
     return message.replace(/\[([a-z0-9_]+)(?:\/([^\]]+))?\]/ig, (match, identifier, fallback) => {
         identifier = identifier.toUpperCase();
         let value = (getValue(identifier) || fallback || '').trim();
-        return value ? filter(value) : '';
+        return value ? filter(value) : match;
     });
 }
 

--- a/routes/archive.js
+++ b/routes/archive.js
@@ -62,20 +62,26 @@ router.get('/:campaign/:list/:subscription', passport.csrfProtection, (req, res,
                         }
 
                         let renderHtml = (html, renderTags) => {
-                            campaign.editorName = campaign.editorName || 'summernote';
-                            let sfx = '';
-                            if (campaign.editorName !== 'summernote' && campaign.editorName !== 'codeeditor') {
-                                sfx = '-raw';
+                            let render = (view, layout) => {
+                                res.render(view, {
+                                    layout,
+                                    message: renderTags ? tools.formatMessage(serviceUrl, campaign, list, subscription, html) : html,
+                                    campaign,
+                                    list,
+                                    subscription,
+                                    attachments,
+                                    csrfToken: req.csrfToken()
+                                });
+                            };
+
+                            if (campaign.editorName && campaign.editorName !== 'summernote' && campaign.editorName !== 'codeeditor') {
+                                res.render('partials/tracking-scripts', { layout: 'archive/layout-raw' }, (err, scripts) => {
+                                    html = scripts ? html.replace(/<\/body\b/i, match => scripts + match) : html;
+                                    render('archive/view-raw', 'archive/layout-raw');
+                                });
+                            } else {
+                                render('archive/view', 'archive/layout');
                             }
-                            res.render('archive/view' + sfx, {
-                                layout: 'archive/layout' + sfx,
-                                message: renderTags ? tools.formatMessage(serviceUrl, campaign, list, subscription, html) : html,
-                                campaign,
-                                list,
-                                subscription,
-                                attachments,
-                                csrfToken: req.csrfToken()
-                            });
                         };
 
                         let renderAndShow = (html, renderTags) => {

--- a/views/archive/layout.hbs
+++ b/views/archive/layout.hbs
@@ -41,24 +41,8 @@
     <script src="/bootstrap/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
 
 
-    {{#if uaCode}}
-        <script>
-            (function(i, s, o, g, r, a, m) {
-                i['GoogleAnalyticsObject'] = r;
-                i[r] = i[r] || function() {
-                    (i[r].q = i[r].q || []).push(arguments)
-                }, i[r].l = 1 * new Date();
-                a = s.createElement(o),
-                    m = s.getElementsByTagName(o)[0];
-                a.async = 1;
-                a.src = g;
-                m.parentNode.insertBefore(a, m)
-            })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-
-            ga('create', '{{uaCode}}', 'auto');
-            ga('send', 'pageview');
-        </script>
-    {{/if}}
+    {{> tracking_scripts}}
+    
 </body>
 
 </html>

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -153,24 +153,8 @@
         <script src="/javascript/editor.js"></script>
     {{/if}}
 
-    {{#if uaCode}}
-        <script>
-            (function(i, s, o, g, r, a, m) {
-                i['GoogleAnalyticsObject'] = r;
-                i[r] = i[r] || function() {
-                    (i[r].q = i[r].q || []).push(arguments)
-                }, i[r].l = 1 * new Date();
-                a = s.createElement(o),
-                    m = s.getElementsByTagName(o)[0];
-                a.async = 1;
-                a.src = g;
-                m.parentNode.insertBefore(a, m)
-            })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+    {{> tracking_scripts}}
 
-            ga('create', '{{uaCode}}', 'auto');
-            ga('send', 'pageview');
-        </script>
-    {{/if}}
 </body>
 
 </html>

--- a/views/partials/tracking-scripts.hbs
+++ b/views/partials/tracking-scripts.hbs
@@ -1,0 +1,18 @@
+{{#if uaCode}}
+    <script>
+        (function(i, s, o, g, r, a, m) {
+            i['GoogleAnalyticsObject'] = r;
+            i[r] = i[r] || function() {
+                (i[r].q = i[r].q || []).push(arguments)
+            }, i[r].l = 1 * new Date();
+            a = s.createElement(o),
+                m = s.getElementsByTagName(o)[0];
+            a.async = 1;
+            a.src = g;
+            m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+
+        ga('create', '{{uaCode}}', 'auto');
+        ga('send', 'pageview');
+    </script>
+{{/if}}


### PR DESCRIPTION
… greedy.

The change in tools.formatMessage() prevents stripping CSS like
a[data-foo] and JS arrays. Thus only replacing mergeTag it knows
about.